### PR TITLE
Hex packet IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/src/main/java/net/beaconpe/magicclient/network/PacketHandler.java
+++ b/src/main/java/net/beaconpe/magicclient/network/PacketHandler.java
@@ -200,7 +200,7 @@ public class PacketHandler extends Thread{
 
     private void handlePacket(byte[] data) throws IOException {
         byte pid = data[0];
-        client.getLogger().debug("Handling packet: PID: "+pid+", length is: "+data.length);
+        client.getLogger().debug("Handling packet: PID: "+String.format("0x%02x", pid)+", length is: "+data.length);
         switch(pid){
             case RAKNET_OPEN_CONNECTION_REPLY_2:
                 client.getLogger().debug("Recieved 0x08!");
@@ -275,7 +275,7 @@ public class PacketHandler extends Thread{
                     break;
 
                 default:
-                    client.getLogger().warn("Unknown packet: "+pid);
+                    client.getLogger().warn("Unknown packet: "+String.format("0x%02x", pid));
                     break;
             }
         }


### PR DESCRIPTION
This has 2 fixes:
1. I couldn't get maven 3.2.5 to work unless I added an explicit &lt;version&gt; element.
2. I changed handlePacket() to log unknown packet IDs as hex instead of a signed int value to make debugging easier.
